### PR TITLE
Allowed podtrac prefixing of mp3 urls

### DIFF
--- a/src/buildFeed.ts
+++ b/src/buildFeed.ts
@@ -65,10 +65,13 @@ export const buildFeed = async (
 
   await Promise.all(
     contents.map(async ({ frontmatter: fm, body, mp3path, filepath }) => {
+      let decoratedMp3URL = feedOptions.podtrac ? 
+        podtracify(safeJoin(myURL, fm.mp3URL)) : 
+        safeJoin(myURL, fm.mp3URL);
       feed.addItem({
         title: fm.title,
         id: safeJoin(myURL, filepath),
-        link: safeJoin(myURL, fm.mp3URL),
+        link: decoratedMp3URL,
         date: parse(fm.date),
         content: body,
         author: [author],
@@ -86,7 +89,7 @@ export const buildFeed = async (
           episode: fm.episode,
           season: fm.season,
           contentEncoded: body,
-          mp3URL: safeJoin(myURL, fm.mp3URL),
+          mp3URL: decoratedMp3URL,
           enclosureLength: fs.statSync(mp3path).size // size in bytes
         }
       });
@@ -99,6 +102,11 @@ export const buildFeed = async (
 
   return feed;
 };
+
+function podtracify(url: string) {
+  const tokens = /http(s)?:\/\/(.+)/.exec(url)
+  return tokens ? `http${tokens[1] && 's'}://dts.podtrac.com/redirect.mp3/${tokens[2]}` : url;
+}
 
 function safeJoin(a: string, b: string) {
   /** strip starting/leading slashes and only use our own */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,7 @@ export interface FeedOptions {
   feed?: string;
   feedLinks?: any;
   hub?: string;
+  podtrac?: boolean;
 
   author: Author;
 


### PR DESCRIPTION
From [PodTrac](https://podtrac.com) docs:

![Measurement Service 2019-03-20 23-11-01](https://user-images.githubusercontent.com/4396759/54722710-6e8c9d80-4b65-11e9-9062-6b108627257a.jpg)

☝️ That's literally all this PR does.