### PR TITLE
Changed podtrac option to generic decorateURL option

### DIFF
--- a/src/buildFeed.ts
+++ b/src/buildFeed.ts
@@ -65,8 +65,8 @@ export const buildFeed = async (
 
   await Promise.all(
     contents.map(async ({ frontmatter: fm, body, mp3path, filepath }) => {
-      let decoratedMp3URL = feedOptions.podtrac ? 
-        podtracify(safeJoin(myURL, fm.mp3URL)) : 
+      let decoratedMp3URL = feedOptions.decorateURL ? 
+        feedOptions.decorateURL(safeJoin(myURL, fm.mp3URL)) : 
         safeJoin(myURL, fm.mp3URL);
       feed.addItem({
         title: fm.title,
@@ -102,11 +102,6 @@ export const buildFeed = async (
 
   return feed;
 };
-
-function podtracify(url: string) {
-  const tokens = /http(s)?:\/\/(.+)/.exec(url)
-  return tokens ? `http${tokens[1] && 's'}://dts.podtrac.com/redirect.mp3/${tokens[2]}` : url;
-}
 
 function safeJoin(a: string, b: string) {
   /** strip starting/leading slashes and only use our own */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,7 +115,7 @@ export interface FeedOptions {
   feed?: string;
   feedLinks?: any;
   hub?: string;
-  podtrac?: boolean;
+  decorateURL?: (url: string) => string;
 
   author: Author;
 


### PR DESCRIPTION
This is _technically_ a breaking change, but it's a result of my short-sightedness with #3. I _may_ be the only consumer of this library who was using that feature, so you might be able to get away with a non-major semver bump.

Me wanna add another tracker!!